### PR TITLE
Fix slack-app-token handling

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -4,7 +4,7 @@ import { run } from './run.js'
 const main = async (): Promise<void> => {
   await run({
     slackChannelId: core.getInput('slack-channel-id', { required: true }),
-    slackToken: core.getInput('slack-token'),
+    slackToken: core.getInput('slack-app-token'),
     githubToken: core.getInput('github-token', { required: true }),
   })
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,7 +4,7 @@ import { run } from './run.js'
 const main = async (): Promise<void> => {
   await run({
     slackChannelId: core.getInput('slack-channel-id', { required: true }),
-    slackToken: core.getInput('slack-app-token'),
+    slackAppToken: core.getInput('slack-app-token'),
     githubToken: core.getInput('github-token', { required: true }),
   })
 }

--- a/src/run.ts
+++ b/src/run.ts
@@ -10,7 +10,7 @@ type Octokit = ReturnType<typeof github.getOctokit>
 
 type Inputs = {
   slackChannelId: string
-  slackToken: string
+  slackAppToken: string
   githubToken: string
 }
 
@@ -34,11 +34,11 @@ export const run = async (inputs: Inputs): Promise<void> => {
   })
   core.info(`Sending blocks: ${JSON.stringify(blocks, undefined, 2)}`)
 
-  if (inputs.slackToken === '') {
-    core.warning('slack-token is not set. Skip sending the message to Slack.')
+  if (inputs.slackAppToken === '') {
+    core.warning('slack-app-token is not set. Skip sending the message to Slack.')
     return
   }
-  const slackClient = new slack.WebClient(inputs.slackToken)
+  const slackClient = new slack.WebClient(inputs.slackAppToken)
   await slackClient.chat.postMessage({
     channel: inputs.slackChannelId,
     blocks,


### PR DESCRIPTION
Even if `slack-app-token` is given, this action does not send a message actually.

```
Warning: slack-token is not set. Skip sending the message to Slack.
```