### PR TITLE
Trim annotation message if too long

### DIFF
--- a/src/slack.ts
+++ b/src/slack.ts
@@ -54,7 +54,13 @@ export const getFailedJobCause = (failedJob: FailedJob, templates: Templates): s
   }
 
   if (failedJob.failureAnnotationMessages.length > 0) {
-    return ['```', ...failedJob.failureAnnotationMessages, '```']
+    const failureAnnotationMessages = failedJob.failureAnnotationMessages.map((message) => {
+      if (message.length > 300) {
+        return message.substring(0, 300) + '...'
+      }
+      return message
+    })
+    return ['```', ...failureAnnotationMessages, '```']
   }
   return []
 }


### PR DESCRIPTION
If a too long annotation message is given, Slack API returns the following error:

```
Error: An API error occurred: invalid_blocks
...
  code: 'slack_webapi_platform_error',
  data: {
    ok: false,
    error: 'invalid_blocks',
    errors: [
      'failed to match all allowed schemas [json-pointer:/blocks/1/text]',
      'must be less than 3001 characters [json-pointer:/blocks/1/text/text]'
    ],
    response_metadata: { messages: [Array], scopes: [Array], acceptedScopes: [Array] }
  }
}
```
