### PR TITLE
Support running this action in a job

### DIFF
--- a/.github/workflows/ts.yaml
+++ b/.github/workflows/ts.yaml
@@ -34,7 +34,9 @@ jobs:
       - run: pnpm test
       - run: pnpm build
 
-      - name: Run quipper/slack-notification-action
+      - run: exit 1
+      - if: always()
+        name: Run quipper/slack-notification-action
         uses: ./
         with:
           slack-channel-id: ABCDEF123

--- a/.github/workflows/ts.yaml
+++ b/.github/workflows/ts.yaml
@@ -34,9 +34,7 @@ jobs:
       - run: pnpm test
       - run: pnpm build
 
-      - run: exit 1
-      - if: always()
-        name: Run quipper/slack-notification-action
+      - name: Run quipper/slack-notification-action
         uses: ./
         with:
           slack-channel-id: ABCDEF123
@@ -64,3 +62,4 @@ jobs:
     timeout-minutes: 5
     steps:
       - run: echo '::error::This is a fixture error.'
+      - run: exit 1

--- a/.github/workflows/ts.yaml
+++ b/.github/workflows/ts.yaml
@@ -62,4 +62,3 @@ jobs:
     timeout-minutes: 5
     steps:
       - run: echo '::error::This is a fixture error.'
-      - run: exit 1

--- a/action.yaml
+++ b/action.yaml
@@ -13,8 +13,9 @@ inputs:
     required: true
     default: ${{ github.token }}
   github-job-status:
-    description: Current job status
+    description: job.status
     default: ${{ job.status }}
+    deprecationMessage: Do not set github-job-status. Keep the default value.
 
   lost-communication-error-message:
     description: Message to send when "The self-hosted runner lost communication with the server" error

--- a/action.yaml
+++ b/action.yaml
@@ -13,8 +13,8 @@ inputs:
     required: true
     default: ${{ github.token }}
   github-job-status:
-    description: job.status
     default: ${{ job.status }}
+    description: The current status of the job. Possible values are success, failure, or cancelled.
     deprecationMessage: Do not set github-job-status. Keep the default value.
 
   lost-communication-error-message:

--- a/action.yaml
+++ b/action.yaml
@@ -12,6 +12,9 @@ inputs:
     description: GitHub token (optional)
     required: true
     default: ${{ github.token }}
+  github-job-status:
+    description: Current job status
+    default: ${{ job.status }}
 
   lost-communication-error-message:
     description: Message to send when "The self-hosted runner lost communication with the server" error

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,7 +7,7 @@ const main = async (): Promise<void> => {
     slackAppToken: core.getInput('slack-app-token'),
     githubToken: core.getInput('github-token', { required: true }),
     lostCommunicationErrorMessage: core.getInput('lost-communication-error-message', { required: true }),
-    githubJobStatus: core.getInput('github-job-status', { required: true }),
+    githubCurrentJobStatus: core.getInput('github-job-status', { required: true }),
   })
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,7 @@ const main = async (): Promise<void> => {
     slackAppToken: core.getInput('slack-app-token'),
     githubToken: core.getInput('github-token', { required: true }),
     lostCommunicationErrorMessage: core.getInput('lost-communication-error-message', { required: true }),
+    githubJobStatus: core.getInput('github-job-status', { required: true }),
   })
 }
 

--- a/src/run.ts
+++ b/src/run.ts
@@ -32,12 +32,12 @@ export const run = async (inputs: Inputs): Promise<void> => {
     case CheckConclusionState.StartupFailure:
       return await send(summary, inputs)
   }
-  if (summary.conclusion === null) {
-    core.info(`job.status: ${inputs.githubJobStatus}`)
-    return
-  }
   // For other conclusions, determine if any job is failed to exclude cancelled ot skipped.
   if (summary.failedJobs.length > 0) {
+    return await send(summary, inputs)
+  }
+  // If this action is called in a running job, determine the conclusion from the job status.
+  if (summary.conclusion === null && inputs.githubJobStatus === 'failure') {
     return await send(summary, inputs)
   }
   core.info('Nothing sent')

--- a/src/run.ts
+++ b/src/run.ts
@@ -13,6 +13,7 @@ type Inputs = {
   slackChannelId: string
   slackAppToken: string
   githubToken: string
+  githubJobStatus: string
 } & Templates
 
 export const run = async (inputs: Inputs): Promise<void> => {
@@ -30,6 +31,10 @@ export const run = async (inputs: Inputs): Promise<void> => {
     case CheckConclusionState.ActionRequired:
     case CheckConclusionState.StartupFailure:
       return await send(summary, inputs)
+  }
+  if (summary.conclusion === null) {
+    core.info(`job.status: ${inputs.githubJobStatus}`)
+    return
   }
   // For other conclusions, determine if any job is failed to exclude cancelled ot skipped.
   if (summary.failedJobs.length > 0) {

--- a/src/run.ts
+++ b/src/run.ts
@@ -25,9 +25,11 @@ export const run = async (inputs: Inputs): Promise<void> => {
   core.endGroup()
 
   if (summary.failedJobs.length > 0) {
+    core.info(`Found ${summary.failedJobs.length} failed jobs`)
     return await send(summary, inputs)
   }
   if (inputs.githubCurrentJobStatus === 'failure') {
+    core.info('The current job is failing')
     return await send(summary, inputs)
   }
   switch (summary.conclusion) {
@@ -49,7 +51,7 @@ const send = async (summary: WorkflowRunSummary, inputs: Inputs) => {
     },
     inputs,
   )
-  core.info(`Sending blocks: ${JSON.stringify(blocks, undefined, 2)}`)
+  core.info(`Sending the message: ${JSON.stringify(blocks, undefined, 2)}`)
 
   if (inputs.slackAppToken === '') {
     core.warning('slack-app-token is not set. Skip sending the message to Slack.')

--- a/src/run.ts
+++ b/src/run.ts
@@ -32,7 +32,7 @@ export const run = async (inputs: Inputs): Promise<void> => {
     case CheckConclusionState.StartupFailure:
       return await send(summary, inputs)
   }
-  // For other conclusions, determine if any job is failed to exclude cancelled ot skipped.
+  // For other conclusions, determine the conclusion from the failed jobs.
   if (summary.failedJobs.length > 0) {
     return await send(summary, inputs)
   }
@@ -49,6 +49,7 @@ const send = async (summary: WorkflowRunSummary, inputs: Inputs) => {
     {
       repository: github.context.repo.repo,
       actor: github.context.actor,
+      jobStatus: inputs.githubJobStatus,
     },
     inputs,
   )

--- a/src/slack.ts
+++ b/src/slack.ts
@@ -4,6 +4,7 @@ import { FailedJob, WorkflowRunSummary } from './workflow-run.js'
 type Context = {
   repository: string
   actor: string
+  jobStatus: string
 }
 
 export type Templates = {
@@ -11,12 +12,13 @@ export type Templates = {
 }
 
 export const getSlackBlocks = (w: WorkflowRunSummary, c: Context, templates: Templates): KnownBlock[] => {
+  const conclusion = w.conclusion?.toLocaleLowerCase() ?? c.jobStatus
   const blocks: KnownBlock[] = [
     {
       type: 'section',
       text: {
         type: 'mrkdwn',
-        text: `Workflow *<${w.workflowRunUrl}|${w.workflowName}>* ${w.conclusion?.toLocaleLowerCase() ?? ''}`,
+        text: `Workflow *<${w.workflowRunUrl}|${w.workflowName}>* ${conclusion}`,
       },
     },
   ]

--- a/src/slack.ts
+++ b/src/slack.ts
@@ -4,7 +4,6 @@ import { FailedJob, WorkflowRunSummary } from './workflow-run.js'
 type Context = {
   repository: string
   actor: string
-  jobStatus: string
 }
 
 export type Templates = {
@@ -12,7 +11,7 @@ export type Templates = {
 }
 
 export const getSlackBlocks = (w: WorkflowRunSummary, c: Context, templates: Templates): KnownBlock[] => {
-  const conclusion = w.conclusion?.toLocaleLowerCase() ?? c.jobStatus
+  const conclusion = w.conclusion?.toLocaleLowerCase() ?? ''
   const blocks: KnownBlock[] = [
     {
       type: 'section',


### PR DESCRIPTION
## Problem to solve
Currently, this action does not handle any failure of the current job.

For example, the below job will show `Nothing sent`.

```yaml
jobs:
  test:
    runs-on: ubuntu-latest
    timeout-minutes: 10
    steps:
      - run: exit 1
      - if: always()
        uses: quipper/slack-notification-action@v2
        with:
          slack-channel-id: TEST
```

## How to solve
Handle the current job status given by `job.status`. See also https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#job-context.
