### PR TITLE
Use current job status for non workflow_run events

### DIFF
--- a/src/run.ts
+++ b/src/run.ts
@@ -48,6 +48,7 @@ const send = async (summary: WorkflowRunSummary, inputs: Inputs) => {
     {
       repository: github.context.repo.repo,
       actor: github.context.actor,
+      currentJobStatus: inputs.githubCurrentJobStatus,
     },
     inputs,
   )

--- a/src/slack.ts
+++ b/src/slack.ts
@@ -4,6 +4,7 @@ import { FailedJob, WorkflowRunSummary } from './workflow-run.js'
 type Context = {
   repository: string
   actor: string
+  currentJobStatus: string
 }
 
 export type Templates = {
@@ -12,13 +13,14 @@ export type Templates = {
 }
 
 export const getSlackBlocks = (w: WorkflowRunSummary, c: Context, templates: Templates): KnownBlock[] => {
-  const conclusion = w.conclusion?.toLocaleLowerCase() ?? ''
+  // When the current workflow run is still running, use the current job status.
+  const conclusion = w.conclusion ?? c.currentJobStatus
   return [
     {
       type: 'section',
       text: {
         type: 'mrkdwn',
-        text: `Workflow *<${w.workflowRunUrl}|${w.workflowName}>* ${conclusion}`,
+        text: `Workflow *<${w.workflowRunUrl}|${w.workflowName}>* ${conclusion.toLocaleLowerCase()}`,
       },
     },
     ...getFailedJobBlocks(w, templates),


### PR DESCRIPTION
When this action is called on push event, the conclusion is empty in the notification message. This will fix it.
