### PR TITLE
Handle "The runner has received a shutdown signal." error

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Otherwise, it inspects the current workflow run.
 | `slack-app-token`                  | (dry-run)       | Bot token of Slack App                                                                 |
 | `github-token`                     | `github.token`  | GitHub token                                                                           |
 | `lost-communication-error-message` | See action.yaml | Message to send when "The self-hosted runner lost communication with the server" error |
+| `shutdown-signal-error-message`    | See action.yaml | Message to send when "The runner has received a shutdown signal" error                 |
 | `mention-message`                  | `github.actor`  | Message to mention the current user                                                    |
 
 ### Outputs

--- a/action.yaml
+++ b/action.yaml
@@ -20,7 +20,11 @@ inputs:
   lost-communication-error-message:
     description: Message to send when "The self-hosted runner lost communication with the server" error
     required: true
-    default: The job was failed due to an infrastructure problem. Please rerun it if needed.
+    default: An infrastructure error occurred. Please rerun it if needed.
+  shutdown-signal-error-message:
+    description: Message to send when "The runner has received a shutdown signal" error
+    required: true
+    default: An infrastructure error occurred. Please rerun it if needed.
   mention-message:
     description: Message to mention the current user. Set to empty to disable mentioning.
     required: false

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,7 @@ const main = async (): Promise<void> => {
       slackChannelId: core.getInput('slack-channel-id', { required: true }),
       slackAppToken: core.getInput('slack-app-token'),
       lostCommunicationErrorMessage: core.getInput('lost-communication-error-message', { required: true }),
+      shutdownSignalErrorMessage: core.getInput('shutdown-signal-error-message', { required: true }),
       mentionMessage: core.getInput('mention-message'),
       githubCurrentJobStatus: core.getInput('github-job-status', { required: true }),
       githubContext: await github.getContext(),

--- a/src/slack.ts
+++ b/src/slack.ts
@@ -9,6 +9,7 @@ type Context = {
 
 export type Templates = {
   lostCommunicationErrorMessage: string
+  shutdownSignalErrorMessage: string
   mentionMessage: string
 }
 
@@ -51,6 +52,9 @@ export const getFailedJobCause = (failedJob: FailedJob, templates: Templates): s
   for (const m of failedJob.failureAnnotationMessages) {
     if (m.match(/The self-hosted runner: .+? lost communication with the server/)) {
       return [templates.lostCommunicationErrorMessage]
+    }
+    if (m.match(/^The runner has received a shutdown signal./)) {
+      return [templates.shutdownSignalErrorMessage]
     }
   }
 

--- a/tests/slack.test.ts
+++ b/tests/slack.test.ts
@@ -5,7 +5,7 @@ import { FailedJob } from '../src/workflow-run.js'
 describe('getFailedJobCause', () => {
   it('should return lostCommunicationErrorMessage when the failureAnnotationMessages contain lost communication message', () => {
     const failedJob: FailedJob = {
-      name: 'job1',
+      name: 'job',
       failureStepNames: [],
       failureAnnotationMessages: [
         'The self-hosted runner: example-vnvrd-runner-98tzt lost communication with the server. Verify the machine is running and has a healthy network connection. Anything in your workflow that terminates the runner process, starves it for CPU/Memory, or blocks its network access can cause this error.',
@@ -13,20 +13,39 @@ describe('getFailedJobCause', () => {
     }
     const templates: Templates = {
       lostCommunicationErrorMessage: 'SORRY',
+      shutdownSignalErrorMessage: 'BYE',
       mentionMessage: '@octocat',
     }
     const cause = getFailedJobCause(failedJob, templates)
     expect(cause).toStrictEqual(['SORRY'])
   })
 
+  it('should return shutdownSignalErrorMessage when the failureAnnotationMessages contain shutdown signal message', () => {
+    const failedJob: FailedJob = {
+      name: 'job',
+      failureStepNames: [],
+      failureAnnotationMessages: [
+        'The runner has received a shutdown signal. This can happen when the runner service is stopped, or a manually started runner is canceled.',
+      ],
+    }
+    const templates: Templates = {
+      lostCommunicationErrorMessage: 'SORRY',
+      shutdownSignalErrorMessage: 'BYE',
+      mentionMessage: '@octocat',
+    }
+    const cause = getFailedJobCause(failedJob, templates)
+    expect(cause).toStrictEqual(['BYE'])
+  })
+
   it('should return empty array when the messages are empty', () => {
     const failedJob: FailedJob = {
-      name: 'job2',
+      name: 'job',
       failureStepNames: [],
       failureAnnotationMessages: [],
     }
     const templates: Templates = {
       lostCommunicationErrorMessage: 'SORRY',
+      shutdownSignalErrorMessage: 'BYE',
       mentionMessage: '@octocat',
     }
     const cause = getFailedJobCause(failedJob, templates)
@@ -35,12 +54,13 @@ describe('getFailedJobCause', () => {
 
   it('should return the messages', () => {
     const failedJob: FailedJob = {
-      name: 'job3',
+      name: 'job',
       failureStepNames: ['Run make'],
       failureAnnotationMessages: ['message1', 'message2'],
     }
     const templates: Templates = {
       lostCommunicationErrorMessage: 'SORRY',
+      shutdownSignalErrorMessage: 'BYE',
       mentionMessage: '@octocat',
     }
     const cause = getFailedJobCause(failedJob, templates)

--- a/tests/slack.test.ts
+++ b/tests/slack.test.ts
@@ -3,7 +3,13 @@ import { getFailedJobCause, Templates } from '../src/slack.js'
 import { FailedJob } from '../src/workflow-run.js'
 
 describe('getFailedJobCause', () => {
-  it('should return lostCommunicationErrorMessage when the failureAnnotationMessages contain lost communication message', () => {
+  const templates: Templates = {
+    lostCommunicationErrorMessage: 'SORRY',
+    shutdownSignalErrorMessage: 'BYE',
+    mentionMessage: '@octocat',
+  }
+
+  it('returns lostCommunicationErrorMessage when the failureAnnotationMessages contain lost communication message', () => {
     const failedJob: FailedJob = {
       name: 'job',
       failureStepNames: [],
@@ -11,16 +17,11 @@ describe('getFailedJobCause', () => {
         'The self-hosted runner: example-vnvrd-runner-98tzt lost communication with the server. Verify the machine is running and has a healthy network connection. Anything in your workflow that terminates the runner process, starves it for CPU/Memory, or blocks its network access can cause this error.',
       ],
     }
-    const templates: Templates = {
-      lostCommunicationErrorMessage: 'SORRY',
-      shutdownSignalErrorMessage: 'BYE',
-      mentionMessage: '@octocat',
-    }
     const cause = getFailedJobCause(failedJob, templates)
     expect(cause).toStrictEqual(['SORRY'])
   })
 
-  it('should return shutdownSignalErrorMessage when the failureAnnotationMessages contain shutdown signal message', () => {
+  it('returns shutdownSignalErrorMessage when the failureAnnotationMessages contain shutdown signal message', () => {
     const failedJob: FailedJob = {
       name: 'job',
       failureStepNames: [],
@@ -28,40 +29,25 @@ describe('getFailedJobCause', () => {
         'The runner has received a shutdown signal. This can happen when the runner service is stopped, or a manually started runner is canceled.',
       ],
     }
-    const templates: Templates = {
-      lostCommunicationErrorMessage: 'SORRY',
-      shutdownSignalErrorMessage: 'BYE',
-      mentionMessage: '@octocat',
-    }
     const cause = getFailedJobCause(failedJob, templates)
     expect(cause).toStrictEqual(['BYE'])
   })
 
-  it('should return empty array when the messages are empty', () => {
+  it('returns empty array when the messages are empty', () => {
     const failedJob: FailedJob = {
       name: 'job',
       failureStepNames: [],
       failureAnnotationMessages: [],
     }
-    const templates: Templates = {
-      lostCommunicationErrorMessage: 'SORRY',
-      shutdownSignalErrorMessage: 'BYE',
-      mentionMessage: '@octocat',
-    }
     const cause = getFailedJobCause(failedJob, templates)
     expect(cause).toStrictEqual([])
   })
 
-  it('should return the messages', () => {
+  it('returns the messages', () => {
     const failedJob: FailedJob = {
       name: 'job',
       failureStepNames: ['Run make'],
       failureAnnotationMessages: ['message1', 'message2'],
-    }
-    const templates: Templates = {
-      lostCommunicationErrorMessage: 'SORRY',
-      shutdownSignalErrorMessage: 'BYE',
-      mentionMessage: '@octocat',
     }
     const cause = getFailedJobCause(failedJob, templates)
     expect(cause).toStrictEqual(['```', 'Run make', 'message1', 'message2', '```'])


### PR DESCRIPTION
This adds a feature to handle the following error:

> The runner has received a shutdown signal. This can happen when the runner service is stopped, or a manually started runner is canceled.

## Issue (internal)
- https://github.com/quipper/aya-issues/issues/84000